### PR TITLE
Refactor VatRateBuilder to use properties file

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="MavenProjectsManager">
@@ -6,6 +7,7 @@
         <option value="$PROJECT_DIR$/pom.xml" />
       </list>
     </option>
+    <option name="workspaceImportForciblyTurnedOn" value="true" />
   </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK" />
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>gustini.library.meinEinkaufApi</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
     <name>gustini.library.meinEinkaufApi</name>
     <url>http://maven.apache.org</url>
     <properties>

--- a/src/main/resources/VatRates.properties
+++ b/src/main/resources/VatRates.properties
@@ -1,0 +1,11 @@
+# vat_rates.properties
+
+# VAT Rates for Switzerland
+vatRate.CH.standard=7.6,7.7,7.8,8.0,8.1
+vatRate.CH.reduced=2.4,2.5,2.6,3.7,3.8
+vatRate.CH.none=0.0
+
+# VAT Rates for Germany
+vatRate.DE.standard=15.0,16.0,19.0
+vatRate.DE.reduced=7.0
+vatRate.DE.none=0.0

--- a/src/test/java/org/gustini/library/meinEinkaufApi/utility/VatRateBuilderTest.java
+++ b/src/test/java/org/gustini/library/meinEinkaufApi/utility/VatRateBuilderTest.java
@@ -1,0 +1,54 @@
+package org.gustini.library.meinEinkaufApi.utility;
+
+import org.gustini.library.meinEinkaufApi.objects.enums.CountryEnum;
+import org.gustini.library.meinEinkaufApi.objects.enums.VatRate;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * VatRateBuilderTest is used to test the functionality of the VatRateBuilder class.
+ * It focuses specifically on testing the getVatRateFromVatRateValue method, ensuring that the method correctly retrieves
+ * the VatRate enumeration value that corresponds to a given CountryEnum and VAT rate percentage value.
+ */
+public class VatRateBuilderTest {
+    
+    @Test
+    public void testGetVatRateFromVatRateValue_GermanyStandardRate() throws IOException {
+        Optional<VatRate> result = VatRateBuilder.getVatRateFromVatRateValue(CountryEnum.DE, 19.0);
+        assertTrue(result.isPresent());
+        assertEquals(VatRate.standard, result.get());
+    }
+    
+    @Test
+    public void testGetVatRateFromVatRateValue_GermanyReducedRate() throws IOException {
+        Optional<VatRate> result = VatRateBuilder.getVatRateFromVatRateValue(CountryEnum.DE, 7.0);
+        assertTrue(result.isPresent());
+        assertEquals(VatRate.reduced, result.get());
+    }
+    
+    @Test
+    public void testGetVatRateFromVatRateValue_SwitzerlandStandardRate() throws IOException {
+        Optional<VatRate> result = VatRateBuilder.getVatRateFromVatRateValue(CountryEnum.CH, 7.7);
+        assertTrue(result.isPresent());
+        assertEquals(VatRate.standard, result.get());
+    }
+    
+    @Test
+    public void testGetVatRateFromVatRateValue_SwitzerlandReducedRate() throws IOException {
+        Optional<VatRate> result = VatRateBuilder.getVatRateFromVatRateValue(CountryEnum.CH, 2.5);
+        assertTrue(result.isPresent());
+        assertEquals(VatRate.reduced, result.get());
+    }
+    
+    @Test
+    public void testGetVatRateFromVatRateValue_NonExistentRate() throws IOException {
+        Optional<VatRate> result = VatRateBuilder.getVatRateFromVatRateValue(CountryEnum.CH, 5.0);
+        assertTrue(result.isEmpty());
+    }
+
+}


### PR DESCRIPTION
The commit transforms the VatRateBuilder's method, getVatRateFromVatRateValue, from the previous switch statement implementation to one that utilizes a properties file. This change simplifies the method and makes adding new VAT rates easier in the future. Tests have been also added to ensure correct functionality of the refactored code. add new vatrate 8.1 (standard rate)